### PR TITLE
Remove some default styles and replace with classes

### DIFF
--- a/src/scss/typography/_body.scss
+++ b/src/scss/typography/_body.scss
@@ -39,7 +39,7 @@ a {
   }
 }
 
-blockquote {
+.iati-quote {
   border-left: 4px solid $color-grey-90;
   padding: 0 $padding-block;
   margin-left: $padding-block;

--- a/src/scss/typography/_code.scss
+++ b/src/scss/typography/_code.scss
@@ -5,6 +5,7 @@
 .iati-code {
   font-family: $font-stack-monospace;
   background-color: $color-grey-10;
+  color: #000;
   border: 1px solid $color-grey-20;
   padding: 0.1em 0.2em;
 
@@ -15,19 +16,10 @@
   }
 }
 
-code {
-  @extend .iati-code;
-}
-
-pre {
-  @extend .iati-code;
-  @extend .iati-code--block;
-}
-
-kbd {
+.iati-kbd {
   @extend .iati-code;
 
-  kbd {
+  .iati-kbd {
     border: none;
   }
 }

--- a/src/scss/typography/typography.stories.ts
+++ b/src/scss/typography/typography.stories.ts
@@ -120,10 +120,14 @@ export const Code: Story = {
       <span>print("This is a block of code")</span>
     </code>
     <p>
-      This paragraph contains a key-binding: <kbd>Ctrl</kbd> + <kbd>C</kbd>.
-      Key-bindings can be nested, e.g.
-      <kbd><kbd>Ctrl</kbd>+<kbd>C</kbd></kbd>
-      .
+      This paragraph contains a key-binding:
+      <kbd class="iati-kbd">Ctrl</kbd> + <kbd class="iati-kbd">C</kbd>
+    </p>
+    <p>
+      Key-bindings can be nested:
+      <kbd class="iati-kbd">
+        <kbd class="iati-kbd">Ctrl</kbd> + <kbd class="iati-kbd">C</kbd>
+      </kbd>
     </p>
   `,
 };

--- a/src/scss/typography/typography.stories.ts
+++ b/src/scss/typography/typography.stories.ts
@@ -93,7 +93,7 @@ export const Quotes: Story = {
       dapibus purus. Vestibulum sed dolor nec libero convallis sollicitudin in
       sed ligula. Nulla aliquet quam at vehicula dictum.
     </p>
-    <blockquote>
+    <blockquote class="iati-quote">
       <p>
         Integer lorem leo, rutrum quis erat in, commodo tincidunt magna. Aenean
         ut libero at dolor tempus porta eget hendrerit mi. Curabitur molestie


### PR DESCRIPTION
Remove default styling for a few html elements and give consumers the option to opt-in to them with classes instead, due to a few clashes with Storybook and Sphinx