### PR TITLE
Use currentColor for piped-list pipe instead of black

### DIFF
--- a/src/scss/components/piped-list/_piped-list.scss
+++ b/src/scss/components/piped-list/_piped-list.scss
@@ -13,7 +13,7 @@
       padding-left: 1em;
     }
     &:not(:last-child) {
-      border-right: 1px solid black;
+      border-right: 1px solid currentColor;
       padding-right: 1em;
     }
   }


### PR DESCRIPTION
Fixes a mistake from https://github.com/IATI/design-system/pull/26

The pipe should be the same colour as the text by default. For example, in the footer the pipe should be white, but I hard-coded it to black in the previous PR.

![Screenshot 2024-11-19 at 17 15 09](https://github.com/user-attachments/assets/28977083-15c8-4cd3-8b7a-3fcf927ef713)
