### PR TITLE
Add ability to apply `iati-button` styles to `<a>` elements

### DIFF
--- a/src/scss/components/button/_button.scss
+++ b/src/scss/components/button/_button.scss
@@ -17,6 +17,7 @@
   padding: 0.7em;
   font-weight: 600;
   transition: all 0.2s ease-in-out;
+  text-decoration: none;
 
   &:hover {
     background-color: $color-teal-80;

--- a/src/scss/components/button/button.stories.ts
+++ b/src/scss/components/button/button.stories.ts
@@ -13,6 +13,10 @@ export const Default: Story = {
   render: () => html`<button class="iati-button">Button</button>`,
 };
 
+export const Link: Story = {
+  render: () => html`<a href="#" class="iati-button">Button</a>`,
+};
+
 export const Light: Story = {
   parameters: {
     backgrounds: {


### PR DESCRIPTION
We sometimes want to use `<a>` instead of `<button>` but still want the same button styles