### PR TITLE
Add extra functionality for cards

### DIFF
--- a/src/scss/components/card/_card.scss
+++ b/src/scss/components/card/_card.scss
@@ -8,6 +8,8 @@
   background-color: white;
   border-top: $border-width solid $color-teal-90;
   padding: $padding-block;
+  display: flex;
+  flex-direction: column;
 
   & :first-child {
     margin-top: 0;

--- a/src/scss/components/card/_card.scss
+++ b/src/scss/components/card/_card.scss
@@ -54,3 +54,17 @@
     }
   }
 }
+
+.iati-card-gallery {
+  --min-card-width: 300px;
+
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  gap: $padding-block;
+
+  & > * {
+    flex: 1;
+    min-width: var(--min-card-width);
+  }
+}

--- a/src/scss/components/card/card.stories.ts
+++ b/src/scss/components/card/card.stories.ts
@@ -41,3 +41,10 @@ export const CardWithMenu: Story = {
     </div>
   `,
 };
+
+export const CardGallery: Story = {
+  render: () =>
+    html`<div class="iati-card-gallery">
+      ${Array(5).fill(Card.render?.call({}))}
+    </div>`,
+};


### PR DESCRIPTION
- Set `display: flex` on `.iati-card`, in order to make positioning children elements easier e.g. being able to set things like `align-self: center` on children
- Create reusable `.iati-card-gallery` component for use cases with several cards together