### PR TITLE
Disable toc on docs pages

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -32,7 +32,6 @@ const preview: Preview = {
       source: {
         format: "dedent",
       },
-      toc: true,
     },
   },
 };


### PR DESCRIPTION
Disabling table of contents on docs pages, as it currently causes a strange screen width bug, e.g. in the below screenshots.

In this one the text is cut off on the left of the main content.

![Screenshot 2025-01-09 at 15 05 31](https://github.com/user-attachments/assets/2608bb49-3190-4f79-87c0-c5abbd1f0ff5)

In this one the main content doesn't fill the full width.

![Screenshot 2025-01-09 at 15 05 39](https://github.com/user-attachments/assets/87f852bb-0786-4db4-897a-7fa0a2985010)
