### PR TITLE
Update stories for long page layout

### DIFF
--- a/src/scss/components/breadcrumb/breadcrumb.stories.ts
+++ b/src/scss/components/breadcrumb/breadcrumb.stories.ts
@@ -14,24 +14,44 @@ const meta: Meta = {
 export default meta;
 type Story = StoryObj;
 
-export const Breadcrumb: Story = {
-  render: () => html`
+const Template = {
+  render: ({ currentPageTitle, previousPageTitles }) => html`
     <nav class="iati-breadcrumb">
       <span class="iati-breadcrumb__previous">
         <i class="iati-icon iati-icon--chevron-left"></i>
-        <a href="#" class="iati-breadcrumb-link">About</a>
+        <a href="#" class="iati-breadcrumb-link"
+          >${previousPageTitles[previousPageTitles.length - 1]}</a
+        >
       </span>
       <ol class="iati-breadcrumb__list">
-        <li class="iati-breadcrumb-item">
-          <a href="#" class="iati-breadcrumb-link">Home</a>
-        </li>
-        <li class="iati-breadcrumb-item">
-          <a href="#" class="iati-breadcrumb-link">About</a>
-        </li>
+        ${previousPageTitles.map(
+          (pageTitle) =>
+            html`<li class="iati-breadcrumb-pageTitle">
+              <a href="#" class="iati-breadcrumb-link">${pageTitle}</a>
+            </li> `,
+        )}
         <li class="iati-breadcrumb-item iati-breadcrumb-item--current">
-          <a aria-current="page" class="iati-breadcrumb-link">Current page</a>
+          <a aria-current="page" class="iati-breadcrumb-link"
+            >${currentPageTitle}</a
+          >
         </li>
       </ol>
     </nav>
   `,
+};
+
+export const TwoLevel: Story = {
+  ...Template,
+  args: {
+    currentPageTitle: "Current Page",
+    previousPageTitles: ["Home"],
+  },
+};
+
+export const ThreeLevel: Story = {
+  ...Template,
+  args: {
+    currentPageTitle: "Current Page",
+    previousPageTitles: ["Home", "About"],
+  },
 };

--- a/src/scss/components/jump-menu/jump-menu.stories.ts
+++ b/src/scss/components/jump-menu/jump-menu.stories.ts
@@ -10,20 +10,20 @@ const meta: Meta = {
   },
 };
 
-const items = [
-  "Page summary",
-  "Narrative",
-  "Assessment",
-  "Exceptions",
-  "comparison with original global partnership indicator methodology",
-  "Pseudocode",
-];
-
 export default meta;
 type Story = StoryObj;
 
 export const Default: Story = {
-  render: () => html`
+  args: {
+    items: [
+      { text: "First section", link: "#" },
+      { text: "Second section", link: "#" },
+      { text: "Another section", link: "#" },
+      { text: "A slightly longer title", link: "#" },
+      { text: "Final section", link: "#" },
+    ],
+  },
+  render: ({ items }) => html`
     <nav class="iati-jump-menu">
       <div class="iati-jump-menu__header">
         <h2 class="iati-jump-menu__title">Jump to section</h2>
@@ -40,9 +40,9 @@ export const Default: Story = {
         class="iati-jump-menu__items js-jump-menu-items"
       >
         ${items.map(
-          (i) =>
+          (item) =>
             html`<li class="iati-jump-menu__item">
-              <a href="#" class="iati-jump-menu__link">${i}</a>
+              <a href=${item.link} class="iati-jump-menu__link">${item.text}</a>
             </li>`,
         )}
       </ul>

--- a/src/scss/components/message/message.stories.ts
+++ b/src/scss/components/message/message.stories.ts
@@ -9,29 +9,35 @@ const meta: Meta = {
       default: "light",
     },
   },
+  argTypes: {
+    type: { control: "select", options: ["notice", "info"] },
+  },
 };
 
 export default meta;
 type Story = StoryObj;
 
-export const Notice: Story = {
-  render: () => html`
-    <p class="iati-message iati-message--notice">
-      You are viewing
-      <span class="iati-message-highlight"
-        >VERSION 2.03 of IATI Standard Reference</span
-      >. <a href="#">View another version</a>.
+const Template = {
+  render: ({ type }) => html`
+    <p class="iati-message ${type ? "iati-message--" + type : ""}">
+      This message is used to
+      <span class="iati-message-highlight">inform the reader</span>
+      of something.
+      <a href="#">Or link to more info.</a>
     </p>
   `,
 };
 
+export const Notice: Story = {
+  args: {
+    type: "notice",
+  },
+  ...Template,
+};
+
 export const Info: Story = {
-  render: () => html`
-    <p class="iati-message iati-message--info">
-      You are viewing
-      <span class="iati-message-highlight"
-        >VERSION 2.03 of IATI Standard Reference</span
-      >. <a href="#">View another version</a>.
-    </p>
-  `,
+  args: {
+    type: "info",
+  },
+  ...Template,
 };

--- a/src/scss/components/section/section.stories.ts
+++ b/src/scss/components/section/section.stories.ts
@@ -15,59 +15,63 @@ const meta: Meta = {
 export default meta;
 type Story = StoryObj;
 
-export const Default: Story = {
-  render: () => html`
-    <div class="iati-section">
-      <h2 class="iati-section__title">About</h2>
-      <div class="iati-section__content">
-        <p>
-          The time-lag statistics attempt to assess how up to date the data
-          is at the point that it is refreshed. For instance a publisher may
-          refresh their data monthly, but the refreshed data is in fact three
-          months old. Alternatively a publisher may only refresh their data once
-          a year, but when they do it contains current data that is less than
-          one month out of date.
-        </p>
-        <p>
-          Transactions are the most numerous and most regularly refreshed
-          elements in reported IATI activities and they are therefore used to
-          make this assessment.
-        </p>
-        <p>
-          The table of statistics shows the number of transaction dates reported
-          in each of the last twelve calendar months. The current month is shown
-          for informational purposes, but excluded from the assessment.
-        </p>
-      </div>
+const Template = {
+  render: ({ title, content, fill, headingId }) => html`
+    <div class=${fill ? "iati-section iati-section--fill" : "iati-section"}>
+      <h2 class="iati-section__title" id=${headingId ? headingId : undefined}>
+        ${title}
+      </h2>
+      <div class="iati-section__content">${content}</div>
     </div>
   `,
 };
 
+export const Default: Story = {
+  ...Template,
+  args: {
+    title: "Section",
+    fill: false,
+    headingId: "section",
+    content: html`
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+        non augue diam. Morbi nibh arcu, pulvinar sit amet erat ut, gravida
+        imperdiet erat. Donec pretium, metus quis tempor iaculis, libero dolor
+        posuere risus, nec mollis arcu orci ac augue. Proin laoreet neque et
+        sagittis vestibulum. Integer commodo tellus arcu, eu placerat ligula
+        tempor sed. Sed mattis nibh in consequat mattis.
+      </p>
+      <p>
+        Vestibulum aliquet viverra sem quis tristique. Nunc a lacinia lacus.
+        Nullam at est ultricies nibh euismod dictum at sit amet libero. Etiam
+        vitae neque eget urna porttitor imperdiet. Mauris efficitur ipsum quis
+        ligula posuere, vel interdum augue elementum. Donec tempor eu turpis
+        eget faucibus. Suspendisse rhoncus pellentesque lacus, non rutrum elit
+        molestie non. Etiam ut magna feugiat ipsum lobortis viverra. Maecenas
+        quam odio, tristique ut condimentum ut, porttitor sed lacus. Phasellus
+        est nisi, molestie ut accumsan id, aliquet vitae lorem.
+      </p>
+    `,
+  },
+};
+
 export const Fill: Story = {
-  render: (args) => html`
-    <div class="iati-section iati-section--fill">
-      <h2 class="iati-section__title">About</h2>
-      <div class="iati-section__content">
-        <p>
-          The time-lag statistics attempt to assess how up to date the data
-          is at the point that it is refreshed. For instance a publisher may
-          refresh their data monthly, but the refreshed data is in fact three
-          months old. Alternatively a publisher may only refresh their data once
-          a year, but when they do it contains current data that is less than
-          one month out of date.
-        </p>
-        <p>
-          Transactions are the most numerous and most regularly refreshed
-          elements in reported IATI activities and they are therefore used to
-          make this assessment.
-        </p>
-        <p>
-          The table of statistics shows the number of transaction dates reported
-          in each of the last twelve calendar months. The current month is shown
-          for informational purposes, but excluded from the assessment.
-        </p>
-        ${Table.render?.call({ ...args })}
-      </div>
-    </div>
-  `,
+  ...Template,
+  args: {
+    title: "Section",
+    fill: true,
+    content: html`
+      <p>
+        Cras ultrices dui sed magna mollis molestie. Morbi a mauris feugiat
+        lorem aliquam viverra eget lobortis ipsum. Vestibulum lobortis nec urna
+        in sagittis. Etiam viverra nibh ut lobortis pretium. Sed varius sapien
+        non lorem lacinia venenatis. Ut porttitor justo eget posuere euismod.
+        Donec vel diam pretium, rhoncus mi id, euismod arcu. Sed ultrices, enim
+        non egestas varius, libero lorem ullamcorper libero, non rutrum leo
+        lacus a enim. Donec consequat ac odio tincidunt posuere. Maecenas
+        maximus tellus nisl, eget ornare ligula vehicula vel.
+      </p>
+      ${Table.render?.call({})}
+    `,
+  },
 };

--- a/src/scss/layout/page/page.stories.ts
+++ b/src/scss/layout/page/page.stories.ts
@@ -1,15 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
 
-import { Breadcrumb } from "../../components/breadcrumb/breadcrumb.stories";
+import { TwoLevel as Breadcrumb } from "../../components/breadcrumb/breadcrumb.stories";
 import { Links as Figures } from "../../components/figures/figures.stories";
 import { Footer } from "../../components/footer/footer.stories";
 import { Header } from "../../components/header/header.stories";
 import { Default as JumpMenu } from "../../components/jump-menu/jump-menu.stories";
-import { Notice as MessageNotice } from "../../components/message/message.stories";
+import { Notice as NoticeMessage } from "../../components/message/message.stories";
 import {
+  Fill as FillSection,
   Default as Section,
-  Fill as Summary,
 } from "../../components/section/section.stories";
 
 const meta: Meta = {
@@ -25,45 +25,86 @@ const meta: Meta = {
 export default meta;
 type Story = StoryObj;
 
-export const BasicLayout: Story = {
-  render: (args) => html`
+export const SimpleLayout: Story = {
+  render: (args, context) => html`
     ${Header.render?.call({ ...args })}
     <main class="iati-main">
-      ${Breadcrumb.render?.call({ ...args })}
-      ${MessageNotice.render?.call({ ...args })}
-      <h1>Page heading</h1>
-      <p>Page contents</p>
+      ${Breadcrumb.render(
+        { ...Breadcrumb.args, currentPageTitle: "Simple Layout" },
+        context,
+      )}
+      ${NoticeMessage.render({ ...NoticeMessage.args }, context)}
+      <h1>Simple Layout</h1>
+      <p>
+        This example shows how to combine components together into a simple page
+        layout.
+      </p>
     </main>
     ${Footer.render?.call({ ...args })}
   `,
 };
 
-export const SidebarLayout: Story = {
-  render: (args) => html`
+export const LongPageLayout: Story = {
+  render: (args, context) => html`
     ${Header.render?.call({ ...args })}
     <main class="iati-main">
       <div class="iati-main__before-content">
-        ${Breadcrumb.render?.call({ ...args })}
-        ${MessageNotice.render?.call({ ...args })}
+        ${Breadcrumb.render(
+          { ...Breadcrumb.args, currentPageTitle: "Long Page Layout" },
+          context,
+        )}
+        ${NoticeMessage.render({ ...NoticeMessage.args }, context)}
+        <h1>Long Page Layout</h1>
+        <p>
+          This example shows how to combine components together into a long page
+          layout. Long pages should include the "Jump to Section" menu, and can
+          make use of the "Section" component to break up content.
+        </p>
       </div>
       <div class="iati-main__content">
         <article class="iati-main__article">
-          <h1>Timeliness</h1>
-          <p>
-            This page provides statistics on the timeliness of IATI data
-            publication by organisations. Timeliness is an important measure of
-            IATI data quality and usefulness.
-          </p>
-          ${Summary.render?.call({ ...args })}
+          ${FillSection.render(
+            { ...FillSection.args, title: "Section A", headingId: "sectionA" },
+            context,
+          )}
           ${Figures.render?.call({ ...args })}
-          ${Section.render?.call({ ...args })}
+          ${Section.render(
+            { ...Section.args, title: "Section B", headingId: "sectionB" },
+            context,
+          )}
+          ${Section.render(
+            {
+              ...Section.args,
+              title: "Section C",
+              fill: true,
+              headingId: "sectionC",
+            },
+            context,
+          )}
+          ${Section.render(
+            { ...Section.args, title: "Section D", headingId: "sectionD" },
+            context,
+          )}
         </article>
         <aside class="iati-main__side iati-main__side--sticky">
-          ${JumpMenu.render?.call({ ...args })}
+          ${JumpMenu.render(
+            {
+              items: [
+                { text: "Section A", link: "#sectionA" },
+                { text: "Section B", link: "#sectionB" },
+                { text: "Section C", link: "#sectionC" },
+                { text: "Section D", link: "#sectionD" },
+              ],
+            },
+            context,
+          )}
         </aside>
       </div>
       <div class="iati-main__after-content">
-        ${Section.render?.call({ ...args })}
+        ${Section.render(
+          { ...Section.args, title: "Section E", fill: true },
+          context,
+        )}
       </div>
     </main>
     ${Footer.render?.call({ ...args })}


### PR DESCRIPTION
No functional changes, Storybook docs only.

- Remove product-specific text from various components in favour of generic text (`JumpMenu`, `Message`, `Section`, `Page`)
- Refactor some stories to enable overriding args when plugging components together in the `Page` stories to make more cohesive examples (`Breadcrumb`, `JumpMenu`, `Section`)
- Update the `LongPageLayout` story to make the `JumpMenu` component work