### PR TITLE
feat: add feedback links to footer

### DIFF
--- a/src/scss/components/footer/_footer.scss
+++ b/src/scss/components/footer/_footer.scss
@@ -31,13 +31,33 @@
   }
 }
 
-.iati-footer__section--first .iati-footer__container {
+.iati-footer__section--first .iati-footer__container,
+.iati-footer__section--mid .iati-footer__container {
   display: flex;
   gap: 2rem;
   flex-direction: column;
   @media (min-width: $screen-md) {
     justify-content: space-between;
     flex-direction: row;
+  }
+}
+
+.iati-footer__section--mid .iati-footer-block:first-child {
+  @media (min-width: $screen-md) {
+    flex: 3;
+  }
+}
+
+.iati-footer__section--mid .iati-footer-block:last-child {
+  @media (min-width: $screen-md) {
+    flex: 2;
+  }
+}
+
+.iati-footer-block--bordered {
+  @media (min-width: $screen-md) {
+    border-inline-start: 1px solid $color-blue-30;
+    padding-inline-start: 2rem;
   }
 }
 
@@ -68,6 +88,13 @@
   }
 }
 
+.iati-footer-block__subtitle {
+  margin: 0 0 0.75rem;
+  font-family: $font-stack-heading;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
 .iati-footer-block__content {
   :where(p, li) {
     margin: 0;
@@ -83,6 +110,11 @@
   & > * {
     flex-grow: 1;
   }
+}
+
+.iati-footer-block__content--divided > *:not(:first-child) {
+  border-inline-start: 1px solid $color-blue-30;
+  padding-inline-start: 2rem;
 }
 
 .iati-footer__legal-nav {

--- a/src/scss/components/footer/footer.stories.ts
+++ b/src/scss/components/footer/footer.stories.ts
@@ -84,14 +84,12 @@ const additionalInformationHtml = html`
           <p>Part of the IATI Unified Platform.</p>
           <p>
             Code licensed under
-            <a href="https://www.gnu.org/licenses/agpl-3.0.en.html"
-              >GNU AGPL</a
+            <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU AGPL</a
             >.
           </p>
           <p>
             Documentation licensed under
-            <a href="https://creativecommons.org/licenses/by/4.0/"
-              >CC BY 3.0</a
+            <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 3.0</a
             >.
           </p>
         </div>

--- a/src/scss/components/footer/footer.stories.ts
+++ b/src/scss/components/footer/footer.stories.ts
@@ -76,34 +76,33 @@ export const UsefulLinksSection: Story = {
 };
 
 const additionalInformationHtml = html`
-  <div class="iati-footer__section">
+  <div class="iati-footer__section iati-footer__section--mid">
     <div class="iati-footer__container">
       <div class="iati-footer-block">
         <h2 class="iati-footer-block__title">Additional Information</h2>
-        <div
-          class="iati-footer-block__content iati-footer-block__content--columns"
-        >
-          <div>
-            <p>Part of the IATI Unified Platform.</p>
-            <p>
-              Code licensed under
-              <a href="https://www.gnu.org/licenses/agpl-3.0.en.html"
-                >GNU AGPL</a
-              >.
-            </p>
-            <p>
-              Documentation licensed under
-              <a href="https://creativecommons.org/licenses/by/4.0/"
-                >CC BY 3.0</a
-              >.
-            </p>
-          </div>
-          <div>
-            <ul>
-              <li><a href="#">Web vX.Y.Z</a></li>
-              <li><a href="#">API vX.Y.Z</a></li>
-            </ul>
-          </div>
+        <div class="iati-footer-block__content">
+          <p>Part of the IATI Unified Platform.</p>
+          <p>
+            Code licensed under
+            <a href="https://www.gnu.org/licenses/agpl-3.0.en.html"
+              >GNU AGPL</a
+            >.
+          </p>
+          <p>
+            Documentation licensed under
+            <a href="https://creativecommons.org/licenses/by/4.0/"
+              >CC BY 3.0</a
+            >.
+          </p>
+        </div>
+      </div>
+      <div class="iati-footer-block iati-footer-block--bordered">
+        <h2 class="iati-footer-block__title">Your Feedback</h2>
+        <div class="iati-footer-block__content">
+          <ul>
+            <li><a href="#">Feedback &amp; Suggestions</a></li>
+            <li><a href="#">Translation Issues &amp; Feedback</a></li>
+          </ul>
         </div>
       </div>
     </div>


### PR DESCRIPTION
@codemacabre I want to introduce the concept of a user feedback link on (almost) every page so that we can start to hear from people in their more day-to-day lives in IATI rather than just when they have an issue that they need to talk to us about. 

I played around with some ideas via chat with Claude Code and this is where I got to. I don't love it, but it does fit the links that I need into a space that has previously been under-used. 

Thoughts welcome - if this is an acceptable design and solution then please merge, or if you'd rather explore alternatives then do say and we can look at it in due course. I'm conscious that we're very short on your time in general and this unblocks other work so I'd be open to a merge-and-improve-later decision as well. 

