### PR TITLE
Data card variations

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dist/js/**/*.js"
   ],
   "scripts": {
-    "start": "storybook dev -p 6006",
+    "start": "storybook dev -p 6006 --no-open",
     "clean": "rm -rf dist",
     "build": "vite build",
     "build:storybook": "storybook build",

--- a/src/scss/components/data-card/_data-card.scss
+++ b/src/scss/components/data-card/_data-card.scss
@@ -6,27 +6,55 @@
 .iati-data-card {
   color: $color-teal-90;
   background-color: $color-teal-20;
-  padding: 1.25rem;
-  padding-top: $padding-block;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
   max-width: 297px;
   text-align: center;
 
-  & :first-child {
-    margin-top: 0;
+  &--header {
+    color: $color-grey-90;
+    background-color: $color-teal-40;
+    padding: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+
+    &-dark {
+      background-color: $color-teal-90;
+      color: white;
+    }
   }
 
-  & :last-child {
-    margin-bottom: 0;
+  &--body {
+    color: $color-teal-90;
+    background-color: $color-teal-20;
+    padding: 1.25rem;
+    padding-top: $padding-block;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    text-align: center;
+
+    & :first-child {
+      margin-top: 0;
+    }
+
+    & :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &--wide {
+    max-width: 100%;
   }
 
   &__title {
     margin: 0;
     font-family: $font-stack-heading;
     font-weight: $font-weight-body-xstrong;
-    font-size: 1.625rem;
+    font-size: 1rem;
+    text-transform: uppercase;
   }
 
   &__tagline {
@@ -45,12 +73,12 @@
   }
 
   &__stat {
-    display: flex;
-    flex-direction: column;
+    display: grid;
     background-color: $color-teal-10;
     padding: 0.75rem;
     gap: 0.5rem;
     min-width: 0;
+    width: min-content;
 
     &:not(:only-child) {
       max-width: calc(50% - 0.25rem);
@@ -69,6 +97,27 @@
       font-size: 1.5rem;
       color: $color-teal-90;
       margin: 0;
+      align-self: end;
+    }
+  }
+
+  &--columns {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.5rem;
+  }
+
+  &--column {
+    font-size: 0.75rem;
+    line-height: 2;
+    text-align: left;
+
+    &-title {
+      color: $color-grey-90;
+      font-size: 0.75rem;
+      font-family: $font-stack-heading;
+      font-weight: $font-weight-heading;
+      text-transform: uppercase;
     }
   }
 

--- a/src/scss/components/data-card/data-card.stories.ts
+++ b/src/scss/components/data-card/data-card.stories.ts
@@ -146,74 +146,73 @@ export const Summary: Story = {
   render: () => html`
     <div class="iati-data-card iati-data-card--wide">
       <header class="iati-data-card--header iati-data-card--header-dark">
-        <h3 class="iati-data-card__title">Headlines</h3>
+        <h3 class="iati-data-card__title">Summary title</h3>
       </header>
       <div class="iati-data-card--body">
         <div class="iati-data-card--columns">
           <div class="iati-data-card--column iati-data-card--column-title">
-            On the registry
+            Datapoint name
           </div>
           <div class="iati-data-card--column">
-            <a href="#">organisation_name</a>
+            <a href="#">link</a>
           </div>
           <div class="iati-data-card--column iati-data-card--column-title">
-            Hierarchies
+            Datapoint name
           </div>
           <div class="iati-data-card--column">
             <code>1</code> <code>2</code>
           </div>
           <div class="iati-data-card--column iati-data-card--column-title">
-            Reporting Org on registry
+            Datapoint name
           </div>
           <div class="iati-data-card--column">
-            <code>ABC-1234567890</code>
+            <code>INLINE CODE BLOCK</code>
           </div>
           <div class="iati-data-card--column iati-data-card--column-title">
-            Licenses
+            Datapoint name
           </div>
           <div class="iati-data-card--column">
-            <span class="iati-reference">other-open</span>
-            <span class="iati-reference">notspecified</span>
+            <span class="iati-reference">reference_item</span>
           </div>
           <div class="iati-data-card--column iati-data-card--column-title">
-            Reporting Org(s) in data
+            Datapoint name
           </div>
           <div class="iati-data-card--column">
-            <code>ABC-1234567890</code>
+            <code>ANOTHER INLINE CODE BLOCK</code>
           </div>
           <div class="iati-data-card--column iati-data-card--column-title">
-            Files failing schema validation
+            Datapoint name
           </div>
-          <div class="iati-data-card--column">0</div>
+          <div class="iati-data-card--column">generic text</div>
         </div>
         <div class="iati-data-card__stats">
           <div class="iati-data-card__stat">
-            <div class="iati-data-card__stat-label">Activity files</div>
-            <div class="iati-data-card__stat-value">2</div>
+            <div class="iati-data-card__stat-label">Big number title</div>
+            <div class="iati-data-card__stat-value">2,000</div>
           </div>
           <div class="iati-data-card__stat">
-            <div class="iati-data-card__stat-label">Organisation files</div>
+            <div class="iati-data-card__stat-label">Small number title</div>
             <div class="iati-data-card__stat-value">1</div>
           </div>
           <div class="iati-data-card__stat">
-            <div class="iati-data-card__stat-label">Total file size</div>
-            <div class="iati-data-card__stat-value">291.8kB</div>
+            <div class="iati-data-card__stat-label">Big number title</div>
+            <div class="iati-data-card__stat-value">291,765</div>
           </div>
           <div class="iati-data-card__stat">
-            <div class="iati-data-card__stat-label">Activities</div>
+            <div class="iati-data-card__stat-label">Small number title</div>
             <div class="iati-data-card__stat-value">19</div>
           </div>
           <div class="iati-data-card__stat">
-            <div class="iati-data-card__stat-label">Unique activities</div>
-            <div class="iati-data-card__stat-value">19</div>
+            <div class="iati-data-card__stat-label">Big number title</div>
+            <div class="iati-data-card__stat-value">1,984</div>
           </div>
           <div class="iati-data-card__stat">
-            <div class="iati-data-card__stat-label">Organisations</div>
+            <div class="iati-data-card__stat-label">Small number title</div>
             <div class="iati-data-card__stat-value">1</div>
           </div>
           <div class="iati-data-card__stat">
-            <div class="iati-data-card__stat-label">Versions</div>
-            <div class="iati-data-card__stat-value">2.03</div>
+            <div class="iati-data-card__stat-label">Big number title</div>
+            <div class="iati-data-card__stat-value">2.073</div>
           </div>
         </div>
       </div>

--- a/src/scss/components/data-card/data-card.stories.ts
+++ b/src/scss/components/data-card/data-card.stories.ts
@@ -17,18 +17,22 @@ type Story = StoryObj;
 export const Stat: Story = {
   render: () => html`
     <div class="iati-data-card">
-      <h3 class="iati-data-card__title">IATI Publishers</h3>
-      <p class="iati-data-card__tagline">
-        How many organisations are publishing IATI data?
-      </p>
-      <div class="iati-data-card__stats">
-        <div class="iati-data-card__stat">
-          <div class="iati-data-card__stat-label">Total Iati Publishers</div>
-          <div class="iati-data-card__stat-value">1719</div>
+      <header class="iati-data-card--header">
+        <h3 class="iati-data-card__title">IATI Publishers</h3>
+      </header>
+      <div class="iati-data-card--body">
+        <p class="iati-data-card__tagline">
+          How many organisations are publishing IATI data?
+        </p>
+        <div class="iati-data-card__stats">
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Total Iati Publishers</div>
+            <div class="iati-data-card__stat-value">1719</div>
+          </div>
         </div>
-      </div>
-      <div class="iati-data-card__button">
-        <button class="iati-button">Learn more about IATI Publishers</button>
+        <div class="iati-data-card__button">
+          <button class="iati-button">Learn more about IATI Publishers</button>
+        </div>
       </div>
     </div>
   `,
@@ -37,33 +41,36 @@ export const Stat: Story = {
 export const ManyStats: Story = {
   render: () => html`
     <div class="iati-data-card">
-      <h3 class="iati-data-card__title">Organisation Identifiers</h3>
-      <p class="iati-data-card__tagline">
-        Which versions of the IATI Standard are being used?
-      </p>
-      <div class="iati-data-card__stats">
-        <div class="iati-data-card__stat">
-          <div class="iati-data-card__stat-label">Active Files</div>
-          <div class="iati-data-card__stat-value">845</div>
+      <header class="iati-data-card--header">
+        <h3 class="iati-data-card__title">Organisation Identifiers</h3>
+      </header>
+      <div class="iati-data-card--body">
+        <p class="iati-data-card__tagline">
+          Which versions of the IATI Standard are being used?
+        </p>
+        <div class="iati-data-card__stats">
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Active Files</div>
+            <div class="iati-data-card__stat-value">845</div>
+          </div>
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Number</div>
+            <div class="iati-data-card__stat-value">$1000</div>
+          </div>
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Stat 3</div>
+            <div class="iati-data-card__stat-value">502,476</div>
+          </div>
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Stat</div>
+            <div class="iati-data-card__stat-value">4071</div>
+          </div>
         </div>
-        <div class="iati-data-card__stat">
-          <div class="iati-data-card__stat-label">Number</div>
-          <div class="iati-data-card__stat-value">$1000</div>
+        <div class="iati-data-card__button">
+          <button class="iati-button">
+            Learn more about Organisation Identifiers
+          </button>
         </div>
-        <div class="iati-data-card__stat">
-          <div class="iati-data-card__stat-label">Stat 3</div>
-          <div class="iati-data-card__stat-value">502,476</div>
-        </div>
-        <div class="iati-data-card__stat">
-          <div class="iati-data-card__stat-label">Stat</div>
-          <div class="iati-data-card__stat-value">4071</div>
-        </div>
-      </div>
-
-      <div class="iati-data-card__button">
-        <button class="iati-button">
-          Learn more about Organisation Identifiers
-        </button>
       </div>
     </div>
   `,
@@ -72,21 +79,25 @@ export const ManyStats: Story = {
 export const Graph: Story = {
   render: () => html`
     <div class="iati-data-card">
-      <h3 class="iati-data-card__title">Codelists</h3>
-      <p class="iati-data-card__tagline">
-        How are codelists used in IATI data?
-      </p>
-      <div class="iati-data-card__graph">
-        <canvas
-          class="iati-data-card__sparkline"
-          data-sparkline='{"labels":["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30"],"values":[100,120,90,150,80,140,110,95,160,75,130,130,132,136,130,70,155,125,95,170,85,60,135,132,80,90,145,110,150,145]}'
-        ></canvas>
-      </div>
-      <div class="iati-data-card__caption">
-        Description below chart showing changes over time
-      </div>
-      <div class="iati-data-card__button">
-        <button class="iati-button">Full Report</button>
+      <header class="iati-data-card--header">
+        <h3 class="iati-data-card__title">Codelists</h3>
+      </header>
+      <div class="iati-data-card--body">
+        <p class="iati-data-card__tagline">
+          How are codelists used in IATI data?
+        </p>
+        <div class="iati-data-card__graph">
+          <canvas
+            class="iati-data-card__sparkline"
+            data-sparkline='{"labels":["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30"],"values":[100,120,90,150,80,140,110,95,160,75,130,130,132,136,130,70,155,125,95,170,85,60,135,132,80,90,145,110,150,145]}'
+          ></canvas>
+        </div>
+        <div class="iati-data-card__caption">
+          Description below chart showing changes over time
+        </div>
+        <div class="iati-data-card__button">
+          <button class="iati-button">Full Report</button>
+        </div>
       </div>
     </div>
   `,
@@ -95,29 +106,116 @@ export const Graph: Story = {
 export const Complete: Story = {
   render: () => html`
     <div class="iati-data-card">
-      <h3 class="iati-data-card__title">IATI Files</h3>
-      <p class="iati-data-card__tagline">How many IATI files are published?</p>
-      <div class="iati-data-card__stats">
-        <div class="iati-data-card__stat">
-          <div class="iati-data-card__stat-label">Big number title</div>
-          <div class="iati-data-card__stat-value">897,548</div>
+      <header class="iati-data-card--header">
+        <h3 class="iati-data-card__title">IATI Files</h3>
+      </header>
+      <div class="iati-data-card--body">
+        <p class="iati-data-card__tagline">
+          How many IATI files are published?
+        </p>
+        <div class="iati-data-card__stats">
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Big number title</div>
+            <div class="iati-data-card__stat-value">897,548</div>
+          </div>
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">
+              Small&nbsp;number title
+            </div>
+            <div class="iati-data-card__stat-value">12</div>
+          </div>
         </div>
-        <div class="iati-data-card__stat">
-          <div class="iati-data-card__stat-label">Small number title</div>
-          <div class="iati-data-card__stat-value">12</div>
+        <div class="iati-data-card__graph">
+          <canvas
+            class="iati-data-card__sparkline"
+            data-sparkline='{"labels":["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30"],"values":[100,120,90,150,80,140,110,95,160,75,130,130,132,136,130,70,155,125,95,170,85,60,135,132,80,90,145,110,150,145]}'
+          ></canvas>
+        </div>
+        <div class="iati-data-card__caption">
+          Description below chart showing changes over time
+        </div>
+        <div class="iati-data-card__button">
+          <button class="iati-button">Full Report</button>
         </div>
       </div>
-      <div class="iati-data-card__graph">
-        <canvas
-          class="iati-data-card__sparkline"
-          data-sparkline='{"labels":["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30"],"values":[100,120,90,150,80,140,110,95,160,75,130,130,132,136,130,70,155,125,95,170,85,60,135,132,80,90,145,110,150,145]}'
-        ></canvas>
-      </div>
-      <div class="iati-data-card__caption">
-        Description below chart showing changes over time
-      </div>
-      <div class="iati-data-card__button">
-        <button class="iati-button">Full Report</button>
+    </div>
+  `,
+};
+
+export const Summary: Story = {
+  render: () => html`
+    <div class="iati-data-card iati-data-card--wide">
+      <header class="iati-data-card--header iati-data-card--header-dark">
+        <h3 class="iati-data-card__title">Headlines</h3>
+      </header>
+      <div class="iati-data-card--body">
+        <div class="iati-data-card--columns">
+          <div class="iati-data-card--column iati-data-card--column-title">
+            On the registry
+          </div>
+          <div class="iati-data-card--column">
+            <a href="#">organisation_name</a>
+          </div>
+          <div class="iati-data-card--column iati-data-card--column-title">
+            Hierarchies
+          </div>
+          <div class="iati-data-card--column">
+            <code>1</code> <code>2</code>
+          </div>
+          <div class="iati-data-card--column iati-data-card--column-title">
+            Reporting Org on registry
+          </div>
+          <div class="iati-data-card--column">
+            <code>ABC-1234567890</code>
+          </div>
+          <div class="iati-data-card--column iati-data-card--column-title">
+            Licenses
+          </div>
+          <div class="iati-data-card--column">
+            <span class="iati-reference">other-open</span>
+            <span class="iati-reference">notspecified</span>
+          </div>
+          <div class="iati-data-card--column iati-data-card--column-title">
+            Reporting Org(s) in data
+          </div>
+          <div class="iati-data-card--column">
+            <code>ABC-1234567890</code>
+          </div>
+          <div class="iati-data-card--column iati-data-card--column-title">
+            Files failing schema validation
+          </div>
+          <div class="iati-data-card--column">0</div>
+        </div>
+        <div class="iati-data-card__stats">
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Activity files</div>
+            <div class="iati-data-card__stat-value">2</div>
+          </div>
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Organisation files</div>
+            <div class="iati-data-card__stat-value">1</div>
+          </div>
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Total file size</div>
+            <div class="iati-data-card__stat-value">291.8kB</div>
+          </div>
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Activities</div>
+            <div class="iati-data-card__stat-value">19</div>
+          </div>
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Unique activities</div>
+            <div class="iati-data-card__stat-value">19</div>
+          </div>
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Organisations</div>
+            <div class="iati-data-card__stat-value">1</div>
+          </div>
+          <div class="iati-data-card__stat">
+            <div class="iati-data-card__stat-label">Versions</div>
+            <div class="iati-data-card__stat-value">2.03</div>
+          </div>
+        </div>
       </div>
     </div>
   `,


### PR DESCRIPTION
This update subtly amends the existing design of data cards to match the Figma and edits their structure to allow for headers and title background colours.

Primarily, this is to add a new 'summary' variant to match the Figma:

<img width="958" height="287" alt="image" src="https://github.com/user-attachments/assets/214089e2-d09a-4c4a-a5bd-3eb3622be858" />

