### PR TITLE
feat: enable URL data sources, multiple sparklines, tooltips & legends

### DIFF
--- a/src/js/components/data-card/data-card.js
+++ b/src/js/components/data-card/data-card.js
@@ -2,83 +2,146 @@ import {
   CategoryScale,
   Chart as ChartJS,
   Filler,
+  Legend,
   LineController,
   LineElement,
   LinearScale,
   PointElement,
+  Tooltip,
 } from "chart.js";
 
-// Register Chart.js components
 ChartJS.register(
   CategoryScale,
   LinearScale,
   PointElement,
+  Legend,
   LineElement,
   LineController,
   Filler,
+  Tooltip,
 );
 
-// Initialise sparklines when DOM is ready
 function initialiseSparklines() {
   const sparklines = document.querySelectorAll(".iati-data-card__sparkline");
 
-  sparklines.forEach((canvas) => {
+  sparklines.forEach(async (canvas) => {
+    if (ChartJS.getChart(canvas)) return;
+
     const dataAttr = canvas.getAttribute("data-sparkline");
+    const dataUrl = canvas.getAttribute("data-url");
 
-    if (dataAttr) {
-      try {
-        const data = JSON.parse(dataAttr);
-        const ctx = canvas.getContext("2d");
+    try {
+      let data = {};
+      let isNested = false;
 
-        new ChartJS(ctx, {
-          type: "line",
-          data: {
-            labels: data.labels,
-            datasets: [
-              {
-                data: data.values,
-                borderColor: "#155366",
-                borderWidth: 2,
-                fill: true,
-                backgroundColor: "#E6F9FE",
-                pointRadius: 0,
-              },
-            ],
-          },
-          options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-              legend: {
-                display: false,
-              },
-            },
-            elements: {
-              point: {
-                radius: 0,
-              },
-            },
-            scales: {
-              y: {
-                display: false,
-              },
-              x: {
-                display: false,
-              },
-            },
-          },
-        });
-      } catch (e) {
-        console.error("Failed to create sparkline:", e);
+      if (dataAttr) {
+        data = JSON.parse(dataAttr);
+      } else if (dataUrl) {
+        const response = await fetch(dataUrl);
+        const result = await response.json();
+
+        const entries = Object.entries(result).sort(
+          ([a], [b]) => new Date(a) - new Date(b),
+        );
+
+        data.labels = entries.map(([key]) =>
+          new Date(key).toLocaleDateString("en-GB", {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+          }),
+        );
+
+        isNested = entries.some(
+          ([, value]) => typeof value === "object" && value !== null,
+        );
+
+        if (isNested) {
+          canvas.parentElement.style.height = "100px";
+
+          const innerKeys = [
+            ...new Set(entries.flatMap(([, value]) => Object.keys(value))),
+          ];
+
+          data.datasets = innerKeys.map((key) => ({
+            label: key,
+            data: entries.map(([, value]) => value[key] ?? 0),
+          }));
+        } else {
+          data.datasets = [{ data: entries.map(([, value]) => value) }];
+        }
       }
+
+      const ctx = canvas.getContext("2d");
+
+      const colors = ["#155366", "#00c497"];
+
+      new ChartJS(ctx, {
+        type: "line",
+        data: {
+          labels: data.labels,
+          datasets: (data.datasets ?? [{ data: data.values }]).map(
+            (dataset, i) => ({
+              ...dataset,
+              borderColor: colors[i % colors.length],
+              borderWidth: 2,
+              fill: !isNested,
+              backgroundColor: "#E6F9FE",
+              pointRadius: 0,
+            }),
+          ),
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              display: isNested,
+              position: "bottom",
+              labels: {
+                pointStyle: "line",
+                usePointStyle: true,
+              },
+            },
+            tooltip: {
+              enabled: true,
+              mode: "nearest",
+              intersect: false,
+              displayColors: isNested,
+              backgroundColor: "rgba(255, 255, 255, 0.9)",
+              titleColor: "#155366",
+              bodyColor: "#155366",
+              callbacks: {
+                label: (context) => `${context.label}: ${context.parsed.y}`,
+                title: () => "",
+              },
+            },
+          },
+          elements: {
+            point: {
+              radius: 0,
+              hitRadius: 10,
+              hoverRadius: 0,
+            },
+          },
+          scales: {
+            y: { display: false },
+            x: { display: false },
+          },
+        },
+      });
+    } catch (e) {
+      console.error("Failed to create sparkline:", e);
     }
   });
 }
 
-// MutationObserver for Storybook dynamic content
 function setupMutationObserver() {
+  let debounceTimer;
+
   const observer = new MutationObserver(() => {
-    setTimeout(initialiseSparklines, 50);
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(initialiseSparklines, 50);
   });
 
   observer.observe(document.body, {
@@ -87,7 +150,6 @@ function setupMutationObserver() {
   });
 }
 
-// Initialise when DOM is ready
 if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", () => {
     initialiseSparklines();

--- a/src/js/components/data-card/data-card.js
+++ b/src/js/components/data-card/data-card.js
@@ -101,6 +101,7 @@ function initialiseSparklines() {
               labels: {
                 pointStyle: "line",
                 usePointStyle: true,
+                color: "#155366",
               },
             },
             tooltip: {

--- a/src/js/components/data-card/data-card.js
+++ b/src/js/components/data-card/data-card.js
@@ -108,6 +108,7 @@ function initialiseSparklines() {
               mode: "nearest",
               intersect: false,
               displayColors: isNested,
+              boxPadding: 4,
               backgroundColor: "rgba(255, 255, 255, 0.9)",
               titleColor: "#155366",
               bodyColor: "#155366",


### PR DESCRIPTION
- Allows URL data sources (such as those on IATI dashboard publisher pages)
- Allows for multiple sparklines, along with legend and tooltips where appropriate:

  <img width="321" height="292" alt="Screenshot_20260428_132329" src="https://github.com/user-attachments/assets/71782e06-e9cf-41c3-8d0a-68a0f7860a72" />
  
  <img width="327" height="342" alt="image" src="https://github.com/user-attachments/assets/fa116441-1a65-436e-8a1f-1d392b29060c" />
