### PR TITLE
feat: adjust data card header and title to match figma

### DIFF
--- a/src/scss/components/data-card/_data-card.scss
+++ b/src/scss/components/data-card/_data-card.scss
@@ -14,17 +14,11 @@
   text-align: center;
 
   &--header {
-    color: $color-grey-90;
-    background-color: $color-teal-40;
-    padding: 0.5rem;
+    color: $color-teal-90;
+    padding: 1rem 1rem 0 1rem;
     display: flex;
     flex-direction: column;
     text-align: center;
-
-    &-dark {
-      background-color: $color-teal-90;
-      color: white;
-    }
   }
 
   &--body {
@@ -54,13 +48,12 @@
     margin: 0;
     font-family: $font-stack-heading;
     font-weight: $font-weight-body-xstrong;
-    font-size: 1rem;
-    text-transform: uppercase;
+    font-size: 1.6rem;
   }
 
   &__tagline {
     margin: 0;
-    font-size: 0.9rem;
+    font-size: 1rem;
     font-weight: $font-weight-body-xstrong;
     line-height: 1.4;
   }


### PR DESCRIPTION
Redesigns the data card headers slightly to match the Figma:

<img width="993" height="922" alt="image" src="https://github.com/user-attachments/assets/cfc025e2-65b8-4afb-b5a7-15321e972ead" />

This also automatically updates the summary data card to match:

<img width="958" height="358" alt="image" src="https://github.com/user-attachments/assets/543d8bc4-5b5b-47c1-a12a-a4b2058682a8" />
